### PR TITLE
custom fillMapper and relative samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ export class AppComponent {
 | padding        | Map each element of data to font padding. Or simply provide a number for global padding. (px)              | Function \| number                            |          | 5                   |
 | font           | The font of text shown                                                                                     | Function \| string                            |          | serif               |
 | autoFill       | Whether texts should be fill with random color or not                                                      | boolean                                       |          | false               |
+| fillMapper | Function used by autoFill to map each data item to a fill color. Can be used to customize the way autoFill generate colors | Function: (word: Word, index: number): string |          | A function based on schemeCategory10 of d3-scale-chromatic|
 
 # Events
 | Name          | Description                                              | Payload                           |

--- a/projects/angular-d3-cloud/src/lib/angular-d3-cloud.component.ts
+++ b/projects/angular-d3-cloud/src/lib/angular-d3-cloud.component.ts
@@ -7,7 +7,6 @@ import { AngularD3Word } from './interfaces';
 
 const fill = scaleOrdinal(schemeCategory10);
 const defaultFontSizeMapper: any = (word: AngularD3Word) => word.value;
-const defaultFillMapper: any = (datum: cloud.Word, index: number) => fill(index.toString());
 @Component({
   selector: 'angular-d3-cloud',
   templateUrl: './angular-d3-cloud.component.html',
@@ -23,7 +22,7 @@ export class AngularD3CloudComponent implements OnChanges, OnInit {
   @Input() fontSizeMapper?: (datum: cloud.Word, index: number) => number = defaultFontSizeMapper
   @Input() rotate?: number | ((datum: cloud.Word, index: number) => number) = 0
   @Input() autoFill?: boolean = true
-  @Input() fillMapper?: (datum: cloud.Word, index: number) => string = defaultFillMapper
+  @Input() fillMapper?: (datum: cloud.Word, index: number) => string;
   @Output() wordClick = new EventEmitter<{ event: MouseEvent, word: cloud.Word }>()
   @Output() wordMouseOver = new EventEmitter<{ event: MouseEvent, word: cloud.Word }>()
   @Output() wordMouseOut = new EventEmitter<{ event: MouseEvent, word: cloud.Word }>()
@@ -80,8 +79,11 @@ export class AngularD3CloudComponent implements OnChanges, OnInit {
           .style('font-size', d => `${d.size}px`)
           .style('font-family', this.font as any)
           .style('fill', (word, i) => {
-            if (this.autoFill && this.fillMapper) {
-              return this.fillMapper(word, i)
+            if (this.autoFill) {
+              if (this.fillMapper)
+                return this.fillMapper(word, i)
+              else
+                return fill(i.toString())
             } else {
               return null
             }
@@ -136,7 +138,7 @@ export class AngularD3CloudComponent implements OnChanges, OnInit {
       throw new TypeError(`${AngularD3CloudComponent.TAG}: [fontSizeMapper] must be a function. Current value is: [${this.fontSizeMapper}]`)
     }
 
-    if (!this.fillMapper || typeof this.fillMapper !== 'function') {
+    if (this.fillMapper && typeof this.fillMapper !== 'function') {
       throw new TypeError(`${AngularD3CloudComponent.TAG}: [fillMapper] must be a function. Current value is: [${this.fillMapper}]`)
     }
 

--- a/projects/angular-d3-cloud/src/lib/angular-d3-cloud.component.ts
+++ b/projects/angular-d3-cloud/src/lib/angular-d3-cloud.component.ts
@@ -7,7 +7,7 @@ import { AngularD3Word } from './interfaces';
 
 const fill = scaleOrdinal(schemeCategory10);
 const defaultFontSizeMapper: any = (word: AngularD3Word) => word.value;
-
+const defaultFillMapper: any = (datum: cloud.Word, index: number) => fill(index.toString());
 @Component({
   selector: 'angular-d3-cloud',
   templateUrl: './angular-d3-cloud.component.html',
@@ -23,6 +23,7 @@ export class AngularD3CloudComponent implements OnChanges, OnInit {
   @Input() fontSizeMapper?: (datum: cloud.Word, index: number) => number = defaultFontSizeMapper
   @Input() rotate?: number | ((datum: cloud.Word, index: number) => number) = 0
   @Input() autoFill?: boolean = true
+  @Input() fillMapper?: (datum: cloud.Word, index: number) => string = defaultFillMapper
   @Output() wordClick = new EventEmitter<{ event: MouseEvent, word: cloud.Word }>()
   @Output() wordMouseOver = new EventEmitter<{ event: MouseEvent, word: cloud.Word }>()
   @Output() wordMouseOut = new EventEmitter<{ event: MouseEvent, word: cloud.Word }>()
@@ -79,8 +80,8 @@ export class AngularD3CloudComponent implements OnChanges, OnInit {
           .style('font-size', d => `${d.size}px`)
           .style('font-family', this.font as any)
           .style('fill', (word, i) => {
-            if (this.autoFill) {
-              return fill(i.toString())
+            if (this.autoFill && this.fillMapper) {
+              return this.fillMapper(word, i)
             } else {
               return null
             }
@@ -133,6 +134,10 @@ export class AngularD3CloudComponent implements OnChanges, OnInit {
 
     if (!this.fontSizeMapper || typeof this.fontSizeMapper !== 'function') {
       throw new TypeError(`${AngularD3CloudComponent.TAG}: [fontSizeMapper] must be a function. Current value is: [${this.fontSizeMapper}]`)
+    }
+
+    if (!this.fillMapper || typeof this.fillMapper !== 'function') {
+      throw new TypeError(`${AngularD3CloudComponent.TAG}: [fillMapper] must be a function. Current value is: [${this.fillMapper}]`)
     }
 
     if (this.rotate === null || this.rotate === undefined || !['number', 'function'].includes(typeof this.rotate) || this.rotate < 0) {

--- a/projects/example/src/app/app.component.html
+++ b/projects/example/src/app/app.component.html
@@ -1,6 +1,6 @@
 <div class="container">
   <div class="jumbotron">
-    <h1 class="display-4">{{title}}}}</h1>
+    <h1 class="display-4">{{title}}</h1>
     <p class="lead">Change the options and click Apply button</p>
     <hr class="my-4">
     <div class="form-inline">

--- a/projects/example/src/app/app.component.html
+++ b/projects/example/src/app/app.component.html
@@ -1,4 +1,34 @@
-<angular-d3-cloud
-  [data]="data"
-  (wordClick)="onWordClick($event)"
-></angular-d3-cloud>
+<div class="container">
+  <div class="jumbotron">
+    <h1 class="display-4">{{title}}}}</h1>
+    <p class="lead">Change the options and click Apply button</p>
+    <hr class="my-4">
+    <div class="form-inline">
+
+        <input class="form-check-input" type="checkbox" id="chkRotate" [checked]="options.rotate" (change) = "options.rotate=!options.rotate">
+        <label class="my-1 mr-3 form-check-label" for="chkRotate">Rotate</label>
+
+        <input class="form-check-input" type="checkbox" id="chkAutoFill" [checked]="options.autoFill" (change) = "options.autoFill=!options.autoFill">
+        <label class="my-1 mr-3 form-check-label" for="chkAutoFill">Auto-Fill</label>
+
+        <label class="my-1 mr-2">Fill Scheme</label>
+        <select class="form-control" [(ngModel)]="options.fillScheme" [disabled]="!options.autoFill">
+          <option *ngFor="let item of schemas" [value]="item.id">{{item.name}}</option>
+        </select>
+        <a class="my-1 ml-3 btn btn-primary" role="button" (click)="applyOptions()">Apply</a>
+    </div>
+  </div>
+
+  <div class="mx-auto" style="width: 800px;">
+    <angular-d3-cloud
+      [data]="data"
+      [width]="800"
+      [height]="600"
+      [padding]="5"
+      [rotate]="rotate"
+      font="impact"
+      [autoFill]="autoFill"
+      [fillMapper]="fillMapper"
+    ></angular-d3-cloud>
+  </div>
+</div>

--- a/projects/example/src/app/app.component.spec.ts
+++ b/projects/example/src/app/app.component.spec.ts
@@ -1,5 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { AppComponent } from './app.component';
+import { AngularD3CloudModule } from 'angular-d3-cloud'
+import { FormsModule } from '@angular/forms';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
@@ -7,6 +9,10 @@ describe('AppComponent', () => {
       declarations: [
         AppComponent
       ],
+      imports: [
+        AngularD3CloudModule,
+        FormsModule
+      ]
     }).compileComponents();
   });
 
@@ -16,16 +22,17 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   });
 
-  it(`should have as title 'example'`, () => {
+  it(`should have as title 'Welcome to d3-cloud-angular demo'`, () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
-    expect(app.title).toEqual('example');
+
+    expect(app.title).toEqual('Welcome to d3-cloud-angular demo');
   });
 
   it('should render title', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement;
-    expect(compiled.querySelector('.content span').textContent).toContain('example app is running!');
+    expect(compiled.querySelector('h1').textContent).toContain('Welcome to d3-cloud-angular demo');
   });
 });

--- a/projects/example/src/app/app.component.ts
+++ b/projects/example/src/app/app.component.ts
@@ -1,4 +1,6 @@
 import { Component } from '@angular/core';
+import { scaleLinear, scaleOrdinal } from 'd3-scale';
+import { schemeCategory10, schemeBlues, schemeGreens, schemePastel1, schemePastel2 } from 'd3-scale-chromatic';
 
 @Component({
   selector: 'app-root',
@@ -7,10 +9,62 @@ import { Component } from '@angular/core';
 })
 export class AppComponent {
   str = 'Exercitation duis ex laboris laboris est aliqua Lorem veniam ad. Minim aliqua enim do exercitation duis eiusmod sunt do exercitation qui ex. Aliqua velit sunt in commodo anim. Sunt labore sunt dolor exercitation non commodo laboris culpa culpa exercitation ex proident laborum.\n\nId dolore commodo occaecat in velit. Aliqua mollit ea qui ad aute est excepteur non aliqua occaecat ad non ea. Labore incididunt excepteur tempor culpa proident ex commodo. Nisi nostrud tempor deserunt ipsum adipisicing aute do adipisicing.\n\nOfficia pariatur eiusmod tempor magna occaecat. Ut proident anim aute aliquip pariatur et. Pariatur ad ea sint ut excepteur amet id do. Labore eu velit non cillum nulla.\n\nIncididunt duis tempor sunt dolor magna occaecat esse elit consequat. Ea sint et labore amet ullamco non tempor. Ad voluptate nisi duis minim elit in adipisicing et laboris nulla culpa ad'
-  data: any = this.str.split(' ').map((d) => {
-    return { text: d, value: 10 + Math.random() * 90, fill: '0' };
-  })
-  
+  data: any;
+
+  public rotate: any = 0;
+  public fillMapper: any;
+  public fillFx: any;
+  public title: string = "Welcome to d3-cloud-angular demo";
+
+  private rotateScale;
+  public autoFill: boolean = true;
+
+  public schemas: any[] = [
+    {"id": 0, "name": "Category10", "schema": schemeCategory10 },
+    {"id": 1, "name": "Blues", "schema": schemeBlues[9] },
+    {"id": 2, "name": "Greens", "schema": schemeGreens[9] },
+    {"id": 3, "name": "Pastel1", "schema": schemePastel1 },
+    {"id": 4, "name": "Pastel2", "schema": schemePastel2 },
+  ];
+
+  public options: any = {
+    autoFill: true,
+    rotate: false,
+    fillScheme: 0
+  };
+
+  constructor() {
+    this.rotateScale = scaleLinear().range([-60, 60]);
+    this.rotateScale.domain([0,1]);
+    this.initData();
+    this.applyOptions();
+  }
+
+  applyOptions() {
+    this.autoFill = this.options.autoFill;
+    if (this.options.rotate) {
+      this.rotate = () => {
+        return this.rotateScale(Math.random());
+      }
+    } else {
+      this.rotate = 0;
+    }
+
+    this.fillFx = scaleOrdinal(this.schemas[this.options.fillScheme].schema);
+
+    this.fillMapper = (datum: any, index: number) => {
+      return this.fillFx(index.toString());
+    }
+
+    this.initData();
+  }
+
+  initData() {
+    this.data = this.str.split(' ').map((d) => {
+      return { text: d, value: 10 + Math.random() * 90, fill: '0' };
+    })
+  }
+
   onWordClick(event: any) {
     console.log(event)
   }

--- a/projects/example/src/app/app.module.ts
+++ b/projects/example/src/app/app.module.ts
@@ -3,6 +3,7 @@ import { NgModule } from '@angular/core';
 
 import { AppComponent } from './app.component';
 import { AngularD3CloudModule } from 'angular-d3-cloud'
+import { FormsModule } from '@angular/forms';
 
 @NgModule({
   declarations: [
@@ -10,7 +11,8 @@ import { AngularD3CloudModule } from 'angular-d3-cloud'
   ],
   imports: [
     BrowserModule,
-    AngularD3CloudModule
+    AngularD3CloudModule,
+    FormsModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/projects/example/src/index.html
+++ b/projects/example/src/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>Example</title>
   <base href="/">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css" integrity="sha384-B0vP5xmATw1+K9KRQjQERJvTumQW0nPEzvF6L/Z6nronJ3oUOFUFpCjEUQouq2+l" crossorigin="anonymous">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 </head>


### PR DESCRIPTION
`fillMapper` is a new function parameter to allow to customize the way autoFill works. It is possible to specify a custom mapping function between (word, index) and the word color.

In the sample I used some scales from **d3-scale-chromatic** and allowed some interaction with main options:

![image](https://user-images.githubusercontent.com/1485446/111699569-98522b00-8838-11eb-8fec-8383e53e5bcd.png)

