### PR TITLE
Fix: Synthetic Default Import for JEST (using UMD)

### DIFF
--- a/projects/angular-d3-cloud/src/lib/angular-d3-cloud.component.ts
+++ b/projects/angular-d3-cloud/src/lib/angular-d3-cloud.component.ts
@@ -1,5 +1,5 @@
 import { Component, ElementRef, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges, ViewChild } from '@angular/core';
-import * as cloud from 'd3-cloud'
+import cloud from 'd3-cloud'
 import { select } from 'd3-selection';
 import 'd3-transition';
 
@@ -159,7 +159,7 @@ export class AngularD3CloudComponent implements OnChanges, OnInit {
       throw new TypeError(`${AngularD3CloudComponent.TAG}: [fontSizeMapper] must be a function. Current value is: [${this.fontSizeMapper}]`)
     }
 
-    if (!this.fillMapper || typeof this.fillMapper !== 'function') {
+    if (this.fillMapper && typeof this.fillMapper !== 'function') {
       throw new TypeError(`${AngularD3CloudComponent.TAG}: [fillMapper] must be a function. Current value is: [${this.fillMapper}]`)
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "downlevelIteration": true,
     "experimentalDecorators": true,
     "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
     "importHelpers": true,
     "target": "es2015",
     "module": "es2020",


### PR DESCRIPTION
Testing a component that uses **d3-cloud-angular** with **JEST** (that uses UMD modules) produce an error:     
```
TypeError: cloud__namespace is not a function

      at AngularD3CloudComponent.Object.<anonymous>.AngularD3CloudComponent.renderCloud (node_modules/projects/angular-d3-cloud/src/lib/angular-d3-cloud.component.ts:62:20)
      at AngularD3CloudComponent.Object.<anonymous>.AngularD3CloudComponent.ngAfterViewInit (node_modules/projects/angular-d3-cloud/src/lib/angular-d3-cloud.component.ts:46:10)
```
I found an easy fix by using "allowSyntheticDefaultImports": true and change the way d3-cloud is imported.
Now I can use the library with JEST without problems.

I also changed again the function check on line 162 because, if the function is optional (as we agreed), the type-check should be done only if the first check (this.fillMapper) is valued as true. 

Infact, leaving the check as was before, unit tests (npm run test) failed and you are forced to pass a function into fillMapper.


